### PR TITLE
Exclude JS template literal placeholders "${...}" from interpolation

### DIFF
--- a/src/js_source.jl
+++ b/src/js_source.jl
@@ -3,7 +3,12 @@ function iterate_interpolations(source::String, result=Union{Expr,JSString,Symbo
     isempty(source) && return result
     while true
         c = source[i]
-        if c == '$'
+
+        # Attempt to parse + interpolate all "$..." expressions, except for "${ ... }"
+        # which is a template literal placeholder in Javascript.
+        #
+        # "{ ... }" is a deprecated syntax in Julia, so this is fine.
+        if c == '$' && i != lindex && source[i + 1] != '{'
             # add elements before $
             if !isempty(lastidx:(i - 1))
                 push!(result, text_func(source[lastidx:(i-1)]))

--- a/test/various.jl
+++ b/test/various.jl
@@ -2,9 +2,9 @@
 
     xx = "hey"; some_js = js"var"; x = [1f0, 2f0]
 
-    js_str = js"console.log($xx); $x; $((2, 4)); $(some_js) hello = 1;"
+    js_str = js"console.log($xx); $x; $((2, 4)); $(some_js) hello = 1; console.log(`${hello}`);"
 
-    expect = "console.log('hey'); Bonito.deserialize_js({\"__javascript_type__\":\"TypedVector\",\"payload\":[1.0,2.0]}); Bonito.deserialize_js([2,4]); var hello = 1;"
+    expect = "console.log('hey'); Bonito.deserialize_js({\"__javascript_type__\":\"TypedVector\",\"payload\":[1.0,2.0]}); Bonito.deserialize_js([2,4]); var hello = 1; console.log(`\${hello}`)"
     @test string(js_str) == expect
 
     asset = Bonito.Asset("file.dun_exist"; check_isfile=false)


### PR DESCRIPTION
This commit carves out a specific exception for "${...}" which is never a useful interpolation from the Julia side (it always errors since `{...}` is a deprecated syntax) and is a template literal placeholder on the Javascript side.

The D3.js examples use this feature heavily, and this small fix is enough to get them working as `js"..."` strings.

There remain other interpolation issues for, e.g., jQuery which uses `$` as a magic global (e.g. `$("button.continue").html("Next Step...")`), but fixing those would be a breaking change to syntax.