### PR TITLE
fix attributes with binary asset (e.g. DOM.img)

### DIFF
--- a/src/rendering/hyperscript_integration.jl
+++ b/src/rendering/hyperscript_integration.jl
@@ -111,7 +111,7 @@ function attribute_render(session::Session, parent, attribute::String, jss::JSCo
     return ""
 end
 
-function attribute_render(session::Session, parent, attribute::String, asset::Union{Link, Asset})
+function attribute_render(session::Session, parent, ::String, asset::AbstractAsset)
     if parent isa Hyperscript.Node{Hyperscript.CSS}
         # css seems to require an url object
         return "url($(url(session, asset)))"


### PR DESCRIPTION
fixes:
```julia
function img2binary(img)
    io = IOBuffer()
    show(io, MIME"image/png"(), img)
    return Bonito.BinaryAsset(take!(io), "image/png")
end

App() do app
    img_array = FileIO.load("...")
    DOM.img(src=img2binary(img_array))
end
```