### PR TITLE
Add `VSCODE_PROXY_URI` support in `find_proxy_in_environment()`

### DIFF
--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -70,6 +70,11 @@ function find_proxy_in_environment()
         # It definitely isn't there without Jupyterlab
         # jupyterlab
         return jupyterlab_proxy_url
+    elseif haskey(ENV, "VSCODE_PROXY_URI")
+        # If VSCode is proxying ports, default to using that, so that we can
+        # work even in environments where we're using `code-server`, and we
+        # may not have any port available other than https.
+        return port -> replace(ENV["VSCODE_PROXY_URI"], "{{port}}" => port)
     else
         # TODO, when to use ip address?
         # Sockets.getipaddr()

--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -52,14 +52,10 @@ function jupyterlab_proxy_url(port)
     end
 end
 
-function on_julia_hub()
-    return haskey(ENV, "JH_APP_URL")
-end
-
 function find_proxy_in_environment()
     if !isempty(SERVER_CONFIGURATION.proxy_url[])
         return port-> SERVER_CONFIGURATION.proxy_url[]
-    elseif on_julia_hub()
+    elseif haskey(ENV, "JH_APP_URL")
         # JuliaHub & VSCode
         return port-> ENV["JH_APP_URL"] * "proxy/$(port)"
     elseif haskey(ENV, "JULIA_WEBIO_BASEURL")


### PR DESCRIPTION
This makes Bonito work out-of-the-box with VSCode-on-the-web
installations such as `code-server`, where the only port available to
the client may be VSCode's HTTPS port.