### PR TITLE
update Dropdown programmatically

### DIFF
--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -219,6 +219,14 @@ function jsrender(session::Session, dropdown::Dropdown)
         }
         element.addEventListener("change", onchange);
         element.selectedIndex = $(dropdown.option_index[] - 1)
+        function set_option_index(index) {
+            if (element.selectedIndex === index - 1) {
+                return
+            }
+            element.selectedIndex = index - 1;
+        }
+        $(dropdown.option_index).on(idx => set_option_index(idx));
+
     }
     """
     option2div(x) = DOM.option(dropdown.option_to_string(x))

--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -226,7 +226,18 @@ function jsrender(session::Session, dropdown::Dropdown)
             element.selectedIndex = index - 1;
         }
         $(dropdown.option_index).on(idx => set_option_index(idx));
-
+        function set_options(opts) {
+        console.log(element.options);
+            element.selectedIndex = 0;
+            while (element.options.length) {
+              element.remove(0);
+            }
+            for (var i = 0; i < opts.length; i++) {
+                var opt = new Option(opts[i], i);
+                element.options.add(opt);
+            }
+        }
+        $(dropdown.options).on(opts => set_options(opts));
     }
     """
     option2div(x) = DOM.option(dropdown.option_to_string(x))


### PR DESCRIPTION
previously, you could update `option_index` programmatically, but the display wouldn't change.  now it does.

```
julia> using Bonito, Observables

julia> options = Observable(["a","b","c"])
Observable(["a", "b", "c"])

julia> V = []
Any[]

julia> app = App() do
           dd = Dropdown(options[])
           push!(V, (; dd))
           return dd
       end

julia> V[1].dd.option_index[]
1

julia> V[1].dd.option_index[]=2
2
```