### PR TITLE
add support for secure connections

### DIFF
--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -58,6 +58,19 @@ route!(server, "/my/nested/page" => App(DOM.div("nested")))
 url_to_visit = online_url(server, "/my/nested/page")
 ```
 
+### Secure HTTPS connections with SSL
+
+If you boss insists your fancy webpage use the `https://` protocol, ask them
+for the SSL certificate and key files, and then launch your Bonito App like
+this:
+
+```
+using MbedTLS
+
+sslconfig = MbedTLS.SSLConfig(<path-to-SSL-certificate-file>, <path-to-SSL-key-file>)
+Bonito.Server(main, url, port, sslconfig=sslconfig)
+```
+
 ### nginx
 
 If you need to re-route Bonito e.g. to host in parallel to PlutoSliderServer, you want a reverse-proxy like `nginx`. We did some testing with nginx and the following configuration worked for us:


### PR DESCRIPTION
closes https://github.com/SimonDanisch/Bonito.jl/issues/220

with these changes, an HTTPS protocol is possible with:

```
sslconfig = MbedTLS.SSLConfig(<path-to-SSL-certificate-file>,<path-to-SSL-key-file>)
Bonito.Server(main, url, port, sslconfig=sslconfig)
```

however!  more work is needed, as the URL to assets still uses "http://", and so they fail to load.  somehow the `protocol` kwarg [here](https://github.com/SimonDanisch/Bonito.jl/blob/master/src/HTTPServer/implementation.jl#L142) needs to know if SSL is being used.  not sure yet how to do that...