### PR TITLE
fix imports in js with NoServer

### DIFF
--- a/src/asset-serving/asset.jl
+++ b/src/asset-serving/asset.jl
@@ -37,7 +37,7 @@ function url(::Nothing, asset::Asset)
     return asset.online_path
 end
 
-function render_asset(session::Session, asset::Asset)
+function render_asset(session::Session, asset_server, asset::Asset)
     @assert mediatype(asset) in (:css, :js, :mjs) "Found: $(mediatype(asset)))"
     ref = url(session, asset)
     if mediatype(asset) == :js
@@ -62,7 +62,6 @@ function jsrender(session::Session, asset::Asset)
     else
         error("Unrecognized asset media type: $(mediatype(asset))")
     end
-    return element
 end
 
 """

--- a/src/session.jl
+++ b/src/session.jl
@@ -320,7 +320,7 @@ function render_dependencies(session::Session)
         # only render the assets that aren't already in root session
         setdiff(session.imports, root_session(session).imports)
     end
-    assets_rendered = render_asset.((session,), assets)
+    assets_rendered = render_asset.(Ref(session), Ref(session.asset_server), assets)
     if any(x-> mediatype(x) == :js && !x.es6module, assets)
         # if a js non es6module is included, we may need to hack require... because JS! :(
         return DOM.div(require_off, assets_rendered..., require_on)


### PR DESCRIPTION
We need to create imports in the header, to be sure that they exist before e.g. `onjs`.
Closes https://github.com/SimonDanisch/Bonito.jl/issues/223