### PR TITLE
enable logging requests

### DIFF
--- a/docs/src/deployment.md
+++ b/docs/src/deployment.md
@@ -60,7 +60,7 @@ url_to_visit = online_url(server, "/my/nested/page")
 
 ### Secure HTTPS connections with SSL
 
-If you boss insists your fancy webpage use the `https://` protocol, ask them
+If the boss insists your fancy webpage use the `https://` protocol, ask them
 for the SSL certificate and key files, and then launch your Bonito App like
 this:
 
@@ -69,6 +69,16 @@ using MbedTLS
 
 sslconfig = MbedTLS.SSLConfig(<path-to-SSL-certificate-file>, <path-to-SSL-key-file>)
 Bonito.Server(main, url, port, sslconfig=sslconfig)
+```
+
+### Logging requests
+
+You want to see who accesses all of your hard work?  No problem!
+
+```
+using HTTP
+access_log = HTTP.logfmt"[$time_iso8601] $remote_addr $request_uri"
+Bonito.Server(main, url, port, access_log=access_log)
 ```
 
 ### nginx

--- a/src/HTTPServer/implementation.jl
+++ b/src/HTTPServer/implementation.jl
@@ -282,9 +282,8 @@ function start(server::Server; verbose=-1, listener_kw...)
     server.server_connection[] = ioserver
     # pass tcp connection to listen, so that we can close the server
 
-    listener = HTTP.Servers.Listener(ioserver; listener_kw...)
     server.server_task[] = @async begin
-        http_server = HTTP.listen!(listener; verbose=verbose) do stream::Stream
+        http_server = HTTP.listen!(server=ioserver; verbose=verbose, listener_kw...) do stream::Stream
             Base.invokelatest(stream_handler, server, stream)
         end
         try

--- a/src/HTTPServer/implementation.jl
+++ b/src/HTTPServer/implementation.jl
@@ -195,14 +195,14 @@ function Server(
         proxy_url = "",
         routes = Routes(),
         websocket_routes = Routes(),
-	listener_kw...
+        listener_kw...
     )
     server = Server(
         url, port, proxy_url,
         Ref{Task}(), Ref{TCPServer}(),
         routes,
         websocket_routes,
-	haskey(listener_kw, :sslconfig) ? "https://" : "http://"
+        haskey(listener_kw, :sslconfig) ? "https://" : "http://"
     )
 
     try
@@ -218,7 +218,7 @@ function Server(
         app::Union{Function, App},
         url::String, port::Int;
         verbose=-1, proxy_url="",
-	listener_kw...
+        listener_kw...
     )
     server = Server(url, port; verbose=verbose, proxy_url=proxy_url, listener_kw...)
     route!(server, "/" => app)


### PR DESCRIPTION
`HTTP.listen` has an `access_log` argument.  not sure why, but passing it into `HTTP.Servers.Listener` doesn't work.

the other commit in this PR simply fixes the carriage returns, and replaces some tabs with spaces.

