### PR TITLE
notify also on falsy values

### DIFF
--- a/js_dependencies/Bonito.bundled.js
+++ b/js_dependencies/Bonito.bundled.js
@@ -3527,9 +3527,7 @@ class Observable {
         this.value = value;
     }
     notify(value, dont_notify_julia) {
-        if (value) {
-            this.value = value;
-        }
+        this.value = value;
         this.#callbacks.forEach((callback)=>{
             try {
                 const deregister = callback(value);

--- a/js_dependencies/Observables.js
+++ b/js_dependencies/Observables.js
@@ -16,9 +16,7 @@ class Observable {
      * @param {boolean} dont_notify_julia
      */
     notify(value, dont_notify_julia) {
-        if (value) {
-            this.value = value;
-        }
+        this.value = value;
         this.#callbacks.forEach((callback) => {
             try {
                 const deregister = callback(value);

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -123,6 +123,28 @@ end
     @test test_dangling_app()
 end
 
+@testset "observable update" begin
+    obs1 = Observable(1)
+    obs2 = Observable(2)
+    obs3 = Observable(3)
+    obs4 = Observable{Any}(4)
+
+    app = App() do session
+        evaljs(session, js"""
+        $obs1.notify(0, true);
+        $obs2.notify($obs1.value);
+        $obs3.notify(12);
+        $obs4.notify(null);
+        """)
+    end
+
+    display(app)
+
+    @test obs1[] == 1
+    @test obs2[] == 0
+    @test obs3[] == 12
+    @test obs4[] === nothing
+end
 
 # @testset "" begin
 #     obs2 = Observable("hey")

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -129,21 +129,22 @@ end
     obs3 = Observable(3)
     obs4 = Observable{Any}(4)
 
-    app = App() do session
-        evaljs(session, js"""
+    function observable_update_app(s, r)
+        evaljs(s, js"""
         $obs1.notify(0, true);
         $obs2.notify($obs1.value);
         $obs3.notify(12);
         $obs4.notify(null);
         """)
+        return DOM.div()
     end
 
-    display(app)
-
-    @test obs1[] == 1
-    @test obs2[] == 0
-    @test obs3[] == 12
-    @test obs4[] === nothing
+    testsession(observable_update_app; port=8555) do app
+        @test obs1[] == 1
+        @test obs2[] == 0
+        @test obs3[] == 12
+        @test obs4[] === nothing
+    end
 end
 
 # @testset "" begin


### PR DESCRIPTION
On  the main branch, the `if` clause before updating the value on JS will prevent the update when `value` is "falsy" (`0`, `""`, `null`, etc).

Simplest way to test is to run

```julia
using Bonito
obs = Observable(1)
app = App() do session
    evaljs(session, js"""
    $obs.notify(0, true);
    console.log($obs.value)
    """)
end
```

on main, the console log shows `1` (no update occurred) and on this PR it shows `0`.

I wonder whether the idea was to allow `obs.notify()`, intending to not update the observable and only trigger callbacks but
- that should probably be done with `value !== undefined`
- on master that also doesn't work, as the julia observable gets updated with `nothing`.