### PR TITLE
fix js_dependency example

### DIFF
--- a/examples/JSModule.js
+++ b/examples/JSModule.js
@@ -1,5 +1,4 @@
-
-const shared_global = 2;
+var shared_global = 2;
 
 export function get_global(){
   return shared_global;

--- a/examples/js_dependency.jl
+++ b/examples/js_dependency.jl
@@ -1,5 +1,5 @@
 using Bonito
-using Bonito: Dependency, onload, @js_str, Session
+using Bonito: onload, @js_str, Session
 using Bonito.DOM
 
 using Deno_jll # If you create your own javascript module, you need to include deno!


### PR DESCRIPTION
- Declaring `shared_global` as const, will lead to the `shared_global` unable to change. Hence the function `set_global` not work.
- The function Dependency was removed in the lastest version, hence cannot be found.