### PR TITLE
clean up possible open tasks on exit

### DIFF
--- a/src/Bonito.jl
+++ b/src/Bonito.jl
@@ -94,6 +94,16 @@ function __init__()
     if !has_html_display()
         browser_display()
     end
+    atexit() do
+        for (task, (task, close_ref)) in Bonito.SERVER_CLEANUP_TASKS
+            close_ref[] = false
+        end
+        Bonito.CURRENT_SESSION[] = nothing
+        if !isnothing(Bonito.GLOBAL_SERVER[])
+            close(Bonito.GLOBAL_SERVER[])
+        end
+        Bonito.GLOBAL_SERVER[] = nothing
+    end
 end
 
 end # module


### PR DESCRIPTION
To e.g. not make precompile hang, if it happens to open a server (which would already happen for `Session()`).