### PR TITLE
Clean js stack before sending to avoid sending/printing too much

### DIFF
--- a/js_dependencies/Connection.js
+++ b/js_dependencies/Connection.js
@@ -15,6 +15,10 @@ const PingPong = "11";
 const UpdateSession = "12";
 const GetSessionDOM = "13"
 
+function clean_stack(stack) {
+    return stack.replaceAll(/(data:\w+\/\w+;base64,)[a-zA-Z0-9\+\/=]+:/g, "$1<<BASE64>>:");
+}
+
 const CONNECTION = {
     send_message: undefined,
     queue: [],
@@ -59,7 +63,7 @@ export function send_error(message, exception) {
         msg_type: JavascriptError,
         message: message,
         exception: String(exception),
-        stacktrace: exception === null ? "" : exception.stack,
+        stacktrace: exception === null ? "" : clean_stack(exception.stack),
     });
 }
 
@@ -80,7 +84,7 @@ export function send_done_loading(session, exception) {
         session,
         message: "",
         exception: exception === null ? "nothing" : String(exception),
-        stacktrace: exception === null ? "" : exception.stack,
+        stacktrace: exception === null ? "" : clean_stack(exception.stack),
     });
 }
 


### PR DESCRIPTION
Currently when exceptions are sent `NoServer` is used for assets, Chrome-based browsers will send the stack including the full base64 of the script for each stack frame. This is quite unwieldy, so here I propose just removing it before sending to the server.