### PR TITLE
Store `@path` for `js_dependencies` in a module const

### DIFF
--- a/src/asset-serving/asset-serving.jl
+++ b/src/asset-serving/asset-serving.jl
@@ -4,12 +4,14 @@ include("asset.jl")
 include("no-server.jl")
 include("http.jl")
 
+const JS_DEPENDENCIES = @path joinpath(@__DIR__, "..", "..", "js_dependencies")
+
 """
     dependency_path(paths...)
 
 Path to serve downloaded dependencies
 """
-dependency_path(paths...) = @path joinpath(@__DIR__, "..", "..", "js_dependencies", paths...)
+dependency_path(paths...) = @path joinpath(JS_DEPENDENCIES, paths...)
 
 const BonitoLib = ES6Module(dependency_path("Bonito.js"))
 const Websocket = ES6Module(dependency_path("Websocket.js"))


### PR DESCRIPTION
Otherwise any runtime usage of `depedency_path` won't have access to the source files.

https://github.com/SimonDanisch/Bonito.jl/blob/cd9583508a6a875ca08d48dc50095a138c503eb7/src/widgets.jl#L420 is the only call site that would be effected by it. The other current usage is all globals, which end up creating separate relocatable files for each rather than reusing the `JS_DEPENDENCIES` one. Would need a fair bit of changes to avoid that, and probably doesn't matter too much, it's not that much extra data being store in the module. 