### PR TITLE
Create src/folder.jl to handle serving of Folder()

### DIFF
--- a/src/Bonito.jl
+++ b/src/Bonito.jl
@@ -35,6 +35,7 @@ include("deno.jl")
 include("types.jl")
 include("HTTPServer/HTTPServer.jl")
 include("app.jl")
+include("folder.jl")
 
 function HTTPServer.route!(server::HTTPServer.Server, routes::Routes)
     for (key, app) in routes.routes

--- a/src/folder.jl
+++ b/src/folder.jl
@@ -1,0 +1,24 @@
+function HTTPServer.apply_handler(folder::Folder, context)
+    target = context.request.target[2:end] # first should be '/' which we want to remove for a path
+    path = abspath(joinpath(folder.path, target))
+    if isfile(path)
+        _, ext = splitext(path)
+        body = read(path)
+        # TODO: use HTTPServer.file_mimetype
+        if ext == ".html"
+            # Bonito.html is just a simple helper to return a HTTP html response
+            return Bonito.html(body)
+        elseif ext == ".css"
+            return HTTP.Response(200, ["Content-Type" => "text/css", "charset" => "utf-8"], body=body)
+        elseif ext == ".js"
+            return HTTP.Response(200, ["Content-Type" => "text/javascript", "charset" => "utf-8"],
+                                 body=body)
+        else
+            @warn "Cannot deal with $ext"
+            return Bonito.HTTPServer.response_404()  # not appropriate! I don't know what to do here.
+        end
+    else
+        @warn "Did not find $target ($path), returning 404"
+        return Bonito.HTTPServer.response_404()
+    end
+end

--- a/src/types.jl
+++ b/src/types.jl
@@ -42,6 +42,10 @@ struct Asset <: AbstractAsset
 end
 
 
+struct Folder
+    path::String
+end
+
 struct Link <: AbstractAsset
     target::String
 end


### PR DESCRIPTION
Hi! So I took your [example](https://discourse.julialang.org/t/bonito-serving-an-html-page/123872/5) from discourse and made it work for my use case. Works great! Sorry that it's in a rough state but I wanted to push this draft before the weekend to get some quick feedback, if you have time.

One of the unfortunate part is that if I serve it as `route!(server, r"/docs/.*" => Folder(joinpath(@__DIR__, "../../MyPackage/build")))`, then because of the `joinpath`, it will lookup `/docs/index.html` in `MyPackage/build/docs/index.html` (whereas I want the path to be `MyPackage/build/index.html`). It's kinda OK, I guess I can use a symlink to get around that, but if you have an elegant proposal I'd be happy to implement it.

TODO:
- [ ] Test
- [ ] Docstring / docs

Thanks!