### PR TITLE
Added a new widget type - Interactive Table.

### DIFF
--- a/js_dependencies/table.css
+++ b/js_dependencies/table.css
@@ -1,26 +1,123 @@
+/* ============================== */
+/*          Default-theme         */
+/* ============================== */
 table {
-  font-family: Arial, Helvetica, sans-serif;
-  border-collapse: collapse;
-  width: 100%;
+    font-family: Arial, Helvetica, sans-serif;
+    border-collapse: collapse;
+    width: 100%;
+    color: #000000;
 }
 
-
-td, th, tr {
+table td,
+table th {
     padding: 1px 5px;
+    resize: horizontal;
+    /* Drag-and-drop column widths */
+    overflow: auto;
+    min-width: 100px;
+    /* Give an initial column width */
+    border: 1px solid #dddddd;
+    /* add a border */
 }
 
-tr:nth-child(even) {
+table tr:nth-child(even) {
     background-color: #f2f2f2;
 }
 
-tr:hover {
-    background-color: #ddd;
+table tr:hover {
+    background-color: #dddddd;
 }
 
-th {
+table th {
     padding-top: 10px;
     padding-bottom: 10px;
     text-align: left;
     background-color: #e2e2e2;
-    color: white;
+    color: #000000;
+    /* font color */
+}
+
+
+/* ============================== */
+/*           Light-theme          */
+/* ============================== */
+.light-theme table {
+    font-family: Arial, Helvetica, sans-serif;
+    border-collapse: collapse;
+    width: 100%;
+    color: #000000;
+}
+
+.light-theme table td,
+.light-theme table th {
+    padding: 1px 5px;
+    resize: horizontal; /* Drag-and-drop column widths */
+    overflow: auto;
+    min-width: 100px; /* Give an initial column width */
+    border: 1px solid #dddddd; /* add a border */
+}
+
+.light-theme table tr:nth-child(even) {
+    background-color: #f2f2f2;
+}
+
+.light-theme table tr:hover {
+    background-color: #dddddd;
+}
+
+.light-theme table th {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    text-align: left;
+    background-color: #e2e2e2;
+    color: #000000; /* font color */
+}
+
+.light-theme table input {
+    background-color: rgba(255, 255, 255, 0.5);
+    color: #000; /* font color */
+    font-size: 14px;
+}
+
+
+/* ============================== */
+/*          Dark-theme            */
+/* ============================== */
+.dark-theme table {
+    font-family: Arial, Helvetica, sans-serif;
+    border-collapse: collapse;
+    width: 100%;
+    color: #ffffff;
+    background-color: #2c2c2c;
+}
+
+.dark-theme table td,
+.dark-theme table th {
+    padding: 1px 5px;
+    resize: horizontal;
+    overflow: auto;
+    min-width: 100px;
+    border: 1px solid #555555;
+}
+
+.dark-theme table tr:nth-child(even) {
+    background-color: #3a3a3a;
+}
+
+.dark-theme table tr:hover {
+    background-color: #444444;
+}
+
+.dark-theme table th {
+    padding-top: 10px;
+    padding-bottom: 10px;
+    text-align: left;
+    background-color: #555555;
+    color: #ffffff;
+}
+
+.dark-theme table input {
+    background-color: rgba(255, 255, 255, 0);
+    color: #fff; /* font color */
+    font-size: 14px;
 }


### PR DESCRIPTION
I created a new widget - Interactive Table. Users can enter data into the table from the frontend and the data will be passed directly to the Julia variable on the backend. This method is meant to replace ms excel for data entry.

I also modified table.css to add a light-theme and a dark-theme, the default is the light-theme.

This is an example code
```julia
using Bonito

dict_table = Dict("Name" => ["Alice", "Bob", "Charlie"], 
    "Age" => [30, 25, 35],
    "Height"=>[170, 180, 300],
)
editable_table = Bonito.InteractTable(dict_table)

app = App() do session::Session
    button = Button("Print Table";
        style=Styles(
            CSS(
                "background-color" => "rgb(80,80,80)",
                "font-size" => "15px",
                "font-weight" => "400",
                "color" => "white",
            ),
            CSS(":focus", "background-color" => "rgb(50,50,50)"),
        ),
    )

    on(button.value) do clicked::Bool
        for (i, row) in enumerate(editable_table.cell_obs)
            row_vals = [cell[] for cell in row]
            println("Row $i = $row_vals") 
        end
        println("---------------")
    end

    button2 = Button(
        "Calculate the total number of ages";
        style=Styles(
            CSS(
                "background-color" => "rgb(80,80,80)",
                "font-size" => "15px",
                "font-weight" => "400",
                "color" => "white",
            ),
            CSS(":focus", "background-color" => "rgb(50,50,50)"),
        ),
    )

    on(button2.value) do clicked::Bool
        sum=0
        for (i, row) in enumerate(editable_table.table["Age"])
            sum+=row
        end
        println("Total $sum years.")
        println("---------------")
    end

    return DOM.div(
        Bonito.jsrender(session, editable_table), button, button2; class="dark-theme"
    )
end
```

![image](https://github.com/user-attachments/assets/d177e868-503c-4b7b-ae77-c92928345765)

Something to do later is to add the description document and the test set. Currently it only supports tables in `Dict{String,Vector}` format. I will add other support in the future.

1/24/2025
It now supports all tables that conform to the Tables.jl interface.