### PR TITLE
jupyter_lab: include base_url in proxy_url

### DIFF
--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -44,7 +44,7 @@ function jupyterlab_proxy_url(port)
         # TODO, how to match kernel?
         hostname = config[1]["hostname"]
         # TODO, this seems very fragile
-        if hostname == "0.0.0.0" || hostname == "localhost"
+        if haskey(ENV, "BONITO_JUPYTER_REMOTE_HOST") || hostname == "0.0.0.0" || hostname == "localhost"
             hostname = get(ENV, "BONITO_JUPYTER_REMOTE_HOST", "none")
             if hostname == "none"
                 hostname = string("http://", IJulia().profile["ip"], ":", config[1]["port"])

--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -45,7 +45,7 @@ function jupyterlab_proxy_url(port)
         hostname = config[1]["hostname"]
         # TODO, this seems very fragile
         if hostname == "0.0.0.0"
-            hostname = get(ENV, "REMOTE_HOST", "none")
+            hostname = get(ENV, "BONITO_JUPYTER_REMOTE_HOST", "none")
             if hostname == "none"
                 hostname = string("http://", IJulia().profile["ip"], ":", config[1]["port"])
             end

--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -44,7 +44,7 @@ function jupyterlab_proxy_url(port)
         # TODO, how to match kernel?
         hostname = config[1]["hostname"]
         # TODO, this seems very fragile
-        if hostname == "0.0.0.0"
+        if hostname == "0.0.0.0" || hostname == "localhost"
             hostname = get(ENV, "BONITO_JUPYTER_REMOTE_HOST", "none")
             if hostname == "none"
                 hostname = string("http://", IJulia().profile["ip"], ":", config[1]["port"])

--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -45,7 +45,7 @@ function jupyterlab_proxy_url(port)
         hostname = config[1]["hostname"]
         # TODO, this seems very fragile
         if hostname == "0.0.0.0"
-            return string("http://", IJulia().profile["ip"], ":", config[1]["port"], "/proxy/", port)
+            return string("http://", IJulia().profile["ip"], ":", config[1]["port"], config[1]["base_url"], "proxy/", port)
         else
             return ""
         end

--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -44,12 +44,10 @@ function jupyterlab_proxy_url(port)
         # TODO, how to match kernel?
         hostname = config[1]["hostname"]
         # TODO, this seems very fragile
-        if haskey(ENV, "BONITO_JUPYTER_REMOTE_HOST") || hostname == "0.0.0.0" || hostname == "localhost"
-            hostname = get(ENV, "BONITO_JUPYTER_REMOTE_HOST", "none")
-            if hostname == "none"
-                hostname = string("http://", IJulia().profile["ip"], ":", config[1]["port"])
-            end
-            return string(hostname, config[1]["base_url"], "proxy/", port)
+        if haskey(ENV, "BONITO_JUPYTER_REMOTE_HOST")
+            return string(get(ENV, "BONITO_JUPYTER_REMOTE_HOST"), config[1]["base_url"], "proxy/", port)
+        elseif hostname == "0.0.0.0" || hostname == "localhost"
+            return string("http://", IJulia().profile["ip"], ":", config[1]["port"], config[1]["base_url"], "proxy/", port)
         else
             return ""
         end

--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -45,7 +45,11 @@ function jupyterlab_proxy_url(port)
         hostname = config[1]["hostname"]
         # TODO, this seems very fragile
         if hostname == "0.0.0.0"
-            return string("http://", IJulia().profile["ip"], ":", config[1]["port"], config[1]["base_url"], "proxy/", port)
+            hostname = getkey(ENV, "REMOTE_HOST", "none")
+            if hostname == "none"
+                hosthame = "http://", IJulia().profile["ip"], ":", config[1]["port"]
+            end
+            return string(hostname, config[1]["base_url"], "proxy/", port)
         else
             return ""
         end

--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -45,9 +45,9 @@ function jupyterlab_proxy_url(port)
         hostname = config[1]["hostname"]
         # TODO, this seems very fragile
         if hostname == "0.0.0.0"
-            hostname = getkey(ENV, "REMOTE_HOST", "none")
+            hostname = get(ENV, "REMOTE_HOST", "none")
             if hostname == "none"
-                hosthame = "http://", IJulia().profile["ip"], ":", config[1]["port"]
+                hostname = string("http://", IJulia().profile["ip"], ":", config[1]["port"])
             end
             return string(hostname, config[1]["base_url"], "proxy/", port)
         else


### PR DESCRIPTION
This adds [base_url](https://jupyterhub.readthedocs.io/en/latest/reference/api/app.html#jupyterhub.app.JupyterHub.base_url) to the jupyterlab proxy_url. By default, base_url = "/" which provides the same behavior. If base_url is different, then the proxy_url should change to reflect this.

to test:

One can recreate the same issue with just the julia-notebook container. Run it interactively to skip the startup script
```
docker run -p 8888:8888 -it quay.io/jupyter/julia-notebook:python-3.12 /bin/bash
```
start jupyter-lab and modify ServerApp.base_url
```
jupyter lab --no-browser --ServerApp.base_url="ipython"
```
open the link in your brower, run the commands in the image and get a websocker error
![image](https://github.com/user-attachments/assets/f023748b-5a8a-425d-bb0b-5f5aa4381cfa)

With this branch the websocket error disappears and pan/zoom works in the scatter plot. 