### PR TITLE
Fix CodeEditor option handling

### DIFF
--- a/src/widgets.jl
+++ b/src/widgets.jl
@@ -478,7 +478,7 @@ function CodeEditor(
         "showPrintMargin" => false,
     )
     user_opts = Dict{String,Any}(string(k) => v for (k, v) in editor_options)
-    options = Dict{String,Any}(merge(user_opts, defaults))
+    options = Dict{String,Any}(merge(defaults, user_opts))
     onchange = Observable(initial_source)
     style = Styles(style,
         "position" => "relative",


### PR DESCRIPTION
`merge(a,b)` will have the entries from the `b` in precedence over `a`. The way it's written right now, user options are overwritten by `defaults` (and thus ignored)

```julia
julia> merge(Dict(1=>2), Dict(1=>4))
Dict{Int64, Int64} with 1 entry:
  1 => 4
```

This commit fixes that.