### PR TITLE
allow to escape interpolation in js_str

### DIFF
--- a/test/basics.jl
+++ b/test/basics.jl
@@ -149,6 +149,20 @@ end
     end
 end
 
+@testset "basic js_str interpolation" begin
+    # does not test anything regarding the js-julia-bridges
+    foo = "foostr"
+    js = js"α$foo" # interpolation after multicodepoint
+    @test string(js) == raw"α'foostr'"
+
+    js = js"α${foo}"
+    @test string(js) == raw"α${foo}"
+
+    id = "#myid"
+    js = js"\$jqref = \$($id)\$"
+    @test string(js) == raw"$jqref = $('#myid')$"
+end
+
 # @testset "" begin
 #     obs2 = Observable("hey")
 #     obs[] = App() do s


### PR DESCRIPTION
Using jquery, it is common to have lots of `$` in your code. It would be nice if that could be escaped, i.e. 
```julia
js"\$jqref = \$('#myel')
```
results in
```js
$jqref = $('#myel')
```

However escaping is hard, so I am not sure if this is really desired. In this implementation, you cannot escape from the escape.