### PR TITLE
turn warn into debug

### DIFF
--- a/src/asset-serving/asset.jl
+++ b/src/asset-serving/asset.jl
@@ -142,12 +142,15 @@ end
 
 
 function generate_bundle_file(file, bundle_file)
+    # If it's an URL we assume it's bundled if the bundle file exists,
+    # since the content of the url should not change (use versions in URLs!)
+    isfile(bundle_file) && is_online(file) && return false
     if isfile(file) || is_online(file)
         if needs_bundling(file, bundle_file)
             bundled, err = deno_bundle(file, bundle_file)
             if !bundled
                 if isfile(bundle_file)
-                    @warn "Failed to bundle $file: $err"
+                    @debug "Failed to bundle $file: $err"
                 else
                     error("Failed to bundle $file: $err")
                 end
@@ -254,7 +257,7 @@ function bundle_path(asset::Asset)
     return asset.bundle_file
 end
 
-last_modified(path::Path) = last_modified(Bonito.getroot(path))
+last_modified(path::Path) = last_modified(getroot(path))
 function last_modified(path::String)
     Dates.unix2datetime(Base.Filesystem.mtime(path))
 end

--- a/src/asset-serving/asset.jl
+++ b/src/asset-serving/asset.jl
@@ -144,7 +144,7 @@ end
 function generate_bundle_file(file, bundle_file)
     # If it's an URL we assume it's bundled if the bundle file exists,
     # since the content of the url should not change (use versions in URLs!)
-    isfile(bundle_file) && is_online(file) && return false
+    isfile(bundle_file) && is_online(file) && return bundle_file
     if isfile(file) || is_online(file)
         if needs_bundling(file, bundle_file)
             bundled, err = deno_bundle(file, bundle_file)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
+# Needs to be done before loading Bonito
+include("test-bundles.jl")
 using Bonito
 # ENV["JULIA_DEBUG"] = Bonito
-
 using Deno_jll
 using Hyperscript, Markdown, Test, RelocatableFolders
 using Observables

--- a/test/test-bundles.jl
+++ b/test/test-bundles.jl
@@ -1,0 +1,17 @@
+using Dates, Test
+
+function last_modified(path::String)
+    return Dates.unix2datetime(Base.Filesystem.mtime(path))
+end
+
+function needs_bundling(path, bundled)
+    !isfile(bundled) && return true
+    # If bundled happen after last modification of asset
+    return last_modified(path) > last_modified(bundled)
+end
+
+path = joinpath(@__DIR__, "..", "js_dependencies")
+bundles(x) = (joinpath(path, x), joinpath(path, replace(x, ".js" => ".bundled.js")))
+@test !needs_bundling(bundles("Bonito.js")...)
+@test !needs_bundling(bundles("Websocket.js")...)
+@test !needs_bundling(bundles("nouislider.min.js")...)


### PR DESCRIPTION
I think github cloning messes with the time stamps of the files, so `needs_bundling` may return true when checked out, and on a read only file system that would lead to a warning even if everything works as expected.