### PR TITLE
fix missing obs

### DIFF
--- a/src/js_source.jl
+++ b/src/js_source.jl
@@ -154,7 +154,6 @@ end
 function inline_code(session::Session, asset_server, js::JSCode)
     # Print code while collecting all interpolated objects in an IdDict
     context = JSSourceContext(session)
-
     code = sprint() do io
         print_js_code(io, js, context)
     end

--- a/src/rendering/hyperscript_integration.jl
+++ b/src/rendering/hyperscript_integration.jl
@@ -103,11 +103,11 @@ end
 
 function attribute_render(session::Session, parent, attribute::String, jss::JSCode)
     # add js after parent gets loaded
-    func = js"""(node) => {
-        node[$attribute] = $(jss)
-    }"""
+    func = js"""(() => {
+        $(parent)[$attribute] = $(jss)
+    })()"""
     # preserve func.file
-    onload(session, parent, JSCode(func.source, jss.file))
+    evaljs(session, JSCode(func.source, jss.file))
     return ""
 end
 


### PR DESCRIPTION
onload would get executed before a script runs, but a script in a dom gets rendered first.
The first object getting rendered uploads the observable, and the following just looks it up, so this leads to a lookup error:
```julia
app = App() do 
    value = Observable(true)
    # because onclick is added via `onload(session, button_dom)` it gets rendered after 
    button_dom = DOM.button("clock", onclick=js"event=> $(value).notify(true);") 
    # the below js script. But then in the final dom `onload` runs before `js"$(value)"`,
    # which is the one inserting `value` into the observable lookup
    DOM.div(button_dom, js"$(value)")
end
```