### PR TITLE
Attemt to fix DOM

### DIFF
--- a/src/app.jl
+++ b/src/app.jl
@@ -149,13 +149,14 @@ function HTTPServer.apply_handler(handler::DisplayHandler, context)
         handler.session = parent
     end
     sub = Session(parent)
-    init_dom = session_dom(parent, App(nothing))
-    sub_dom = session_dom(sub, handler.current_app; html_document=true)
-    # first time rendering in a subsession, we combine init of parent session
-    # with the dom we're rendering right now by putting parent fragment into sub body
-    _, body, _ = find_head_body(sub_dom)
-    pushfirst!(children(body), init_dom)
-    html_str = sprint(io -> print_as_page(io, sub_dom))
+    parent_dom = session_dom(parent, App(nothing); html_document=true)
+    sub_dom = session_dom(sub, handler.current_app)
+
+    # first time rendering in a subsession, we put the
+    # subsession dom as a bonito fragment into the parent body
+    _, parent_body, _ = find_head_body(parent_dom)
+    push!(children(parent_body), sub_dom)
+    html_str = sprint(io -> print_as_page(io, parent_dom))
     # The closing time is calculated from here
     # If after 20s after rendering and sending the HTML to the browser
     # no connection is established, it will be assumed that the browser never connected

--- a/src/app.jl
+++ b/src/app.jl
@@ -149,12 +149,13 @@ function HTTPServer.apply_handler(handler::DisplayHandler, context)
         handler.session = parent
     end
     sub = Session(parent)
-    init_dom = session_dom(parent, App(nothing); html_document=true)
-    sub_dom = session_dom(sub, handler.current_app)
+    init_dom = session_dom(parent, App(nothing))
+    sub_dom = session_dom(sub, handler.current_app; html_document=true)
     # first time rendering in a subsession, we combine init of parent session
-    # with the dom we're rendering right now
-    dom = DOM.div(init_dom, sub_dom)
-    html_str = sprint(io -> print_as_page(io, dom))
+    # with the dom we're rendering right now by putting parent fragment into sub body
+    _, body, _ = find_head_body(sub_dom)
+    pushfirst!(children(body), init_dom)
+    html_str = sprint(io -> print_as_page(io, sub_dom))
     # The closing time is calculated from here
     # If after 20s after rendering and sending the HTML to the browser
     # no connection is established, it will be assumed that the browser never connected

--- a/src/session.jl
+++ b/src/session.jl
@@ -406,7 +406,8 @@ function session_dom(session::Session, dom::Node; init=true, html_document=false
     session_style = render_stylesheets!(root_session(session), session.stylesheets)
     issubsession = !isroot(session)
 
-    @assert xor(issubsession, html_document)
+    # should never request full html_doc for subsession
+    issubsession && @assert !html_document
     if issubsession && !isnothing(head) && !isnothing(body)
         @warn "Apps with head/body elements are not supported in subsessions, wrapping in a fragment"
         dom = page_to_fragment(head, body, dom)

--- a/src/session.jl
+++ b/src/session.jl
@@ -406,10 +406,10 @@ function session_dom(session::Session, dom::Node; init=true, html_document=false
     session_style = render_stylesheets!(root_session(session), session.stylesheets)
     issubsession = !isroot(session)
 
-    @assert xor(subsession, html_document)
+    @assert xor(issubsession, html_document)
     if issubsession && !isnothing(head) && !isnothing(body)
         @warn "Apps with head/body elements are not supported in subsessions, wrapping in a fragment"
-        dom = page_to_fragment(dom)
+        dom = page_to_fragment(head, body, dom)
         head = body = nothing
     end
 
@@ -476,9 +476,7 @@ function session_dom(session::Session, dom::Node; init=true, html_document=false
     return dom
 end
 
-function page_to_fragment(page)
-    head, body, dom = Bonito.find_head_body(page)
-
+function page_to_fragment(head, body, dom)
     _head = Hyperscript.Node(
         Hyperscript.context(head),
         "div",
@@ -492,10 +490,10 @@ function page_to_fragment(page)
         Hyperscript.attrs(body)
     )
     return Hyperscript.Node(
-        Hyperscript.context(page),
+        Hyperscript.context(dom),
         "div",
         [_head, _body],
-        Hyperscript.attrs(page)
+        Hyperscript.attrs(dom)
     )
 end
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -94,6 +94,10 @@ function Base.push!(set::OrderedSet, item)
     (item in set.items) || push!(set.items, item)
 end
 
+function Base.setdiff(set1::OrderedSet{T}, set2) where {T}
+    OrderedSet{T}(setdiff(set1.items, set2))
+end
+
 function Base.union!(set1::OrderedSet, set2)
     union!(set1.items, set2)
 end


### PR DESCRIPTION
This PR tries two things:

- do not wrap `Assets` in `<head>` in `<div>` as this seems to be invalid HTML
- in browser display, don't combine parent init and sub init in a div but instead render the sub init DOM and put the parent init fragment as the first body node