### PR TITLE
separate cache in serialized message

### DIFF
--- a/js_dependencies/Bonito.bundled.js
+++ b/js_dependencies/Bonito.bundled.js
@@ -3668,7 +3668,7 @@ function process_message(data) {
                 data.payload();
                 break;
             case FusedMessage:
-                data.payload.forEach(process_message);
+                data.payload[1].forEach(process_message);
                 break;
             case PingPong:
                 console.debug("ping");
@@ -3832,9 +3832,7 @@ register_ext(108, (uint_8_array)=>{
     return div;
 });
 function decode_binary(binary, compression_enabled) {
-    const serialized_message = unpack_binary(binary, compression_enabled);
-    const [session_id, message_data] = serialized_message;
-    return message_data;
+    return unpack_binary(binary, compression_enabled);
 }
 function init_session(session_id, binary_messages, session_status, compression_enabled) {
     track_deleted_sessions();
@@ -3986,8 +3984,16 @@ register_ext(106, (uint_8_array)=>{
     return session_id;
 });
 register_ext(107, (uint_8_array)=>{
-    const [session_id, message] = unpack(uint_8_array);
-    return message;
+    const [session_cache_bytes, data_bytes] = unpack(uint_8_array);
+    if (session_cache_bytes.length > 0) {
+        unpack(session_cache_bytes);
+    }
+    return unpack(data_bytes);
+});
+register_ext(109, (uint_8_array)=>{
+    const session_caches = unpack(uint_8_array);
+    const result = session_caches.map(unpack);
+    return result;
 });
 function base64encode(data_as_uint8array) {
     const base64_promise = new Promise((resolve)=>{

--- a/js_dependencies/Connection.js
+++ b/js_dependencies/Connection.js
@@ -186,7 +186,7 @@ export function process_message(data) {
                 data.payload();
                 break;
             case FusedMessage:
-                data.payload.forEach(process_message);
+                data.payload[1].forEach(process_message);
                 break;
             case PingPong:
                 // just getting a ping, nothing to do here :)

--- a/src/js_source.jl
+++ b/src/js_source.jl
@@ -147,7 +147,7 @@ end
 # TODO, NoServer is kind of misussed here, since Pluto happens to use it
 # I guess the best solution would be a trait system or some other config object
 # for deciding how to inline code into pure HTML
-function inline_code(session::Session, noserver, source::String)
+function inline_code(::Session, noserver, source::String)
     return DOM.script(source; type="module")
 end
 

--- a/src/serialization/msgpack.jl
+++ b/src/serialization/msgpack.jl
@@ -160,6 +160,10 @@ function decode_extension_and_addbits(ext::MsgPack.Extension)
         elseif DOM_NODE_TAG == ext.type
             tag, children, attributes = decode_extension_and_addbits(MsgPack.unpack(ext.data))
             return Hyperscript.Node{Hyperscript.HTMLSVG}(Hyperscript.DEFAULT_HTMLSVG_CONTEXT, tag, children, attributes)
+        elseif SERIALIZED_MESSAGE_TAG == ext.type
+            unpacked = unpack(ext.data)
+            bytes = decode_extension_and_addbits.(unpacked)
+            return decode_extension_and_addbits.(unpack.(bytes))
         elseif ARRAY_TAG == ext.type
             data = MsgPack.unpack(ext.data)
             unpacked = decode_extension_and_addbits(data)

--- a/src/serialization/msgpack.jl
+++ b/src/serialization/msgpack.jl
@@ -76,6 +76,7 @@ const DOM_NODE_TAG = Int8(105)
 const SESSION_CACHE_TAG = Int8(106)
 const SERIALIZED_MESSAGE_TAG = Int8(107)
 const RAW_HTML_TAG = Int8(108)
+const SESSION_CACHES_TAG = Int8(109);
 
 MsgPack.msgpack_type(::Type{<: SerializedObservable}) = MsgPack.ExtensionType()
 
@@ -118,9 +119,17 @@ function MsgPack.to_msgpack(::MsgPack.ExtensionType, x::SessionCache)
     return MsgPack.Extension(SESSION_CACHE_TAG, pack([x.session_id, x.objects, x.session_type]))
 end
 
+MsgPack.msgpack_type(::Type{SessionCaches}) = MsgPack.ExtensionType()
+function MsgPack.to_msgpack(::MsgPack.ExtensionType, x::SessionCaches)
+    return MsgPack.Extension(
+        SESSION_CACHES_TAG,
+        pack(x.bytes),
+    )
+end
+
 MsgPack.msgpack_type(::Type{SerializedMessage}) = MsgPack.ExtensionType()
 function MsgPack.to_msgpack(::MsgPack.ExtensionType, x::SerializedMessage)
-    return MsgPack.Extension(SERIALIZED_MESSAGE_TAG, x.bytes)
+    return MsgPack.Extension(SERIALIZED_MESSAGE_TAG, pack([x.session_cache, x.bytes]))
 end
 
 

--- a/src/serialization/types.jl
+++ b/src/serialization/types.jl
@@ -31,6 +31,11 @@ function SessionCache(session::Session, objects::Dict{String,Any})
     )
 end
 
+# Many serialized caches
+struct SessionCaches
+    bytes::Vector{Vector{UInt8}}
+end
+
 # We want typed arrays to arrive as JS typed arrays
 const JSTypedArrayEltypes = [Int8, UInt8, Int16, UInt16, Int32, UInt32, Float32, Float64]
 const JSTypedNumber = Union{JSTypedArrayEltypes...}

--- a/src/session.jl
+++ b/src/session.jl
@@ -43,7 +43,15 @@ end
 
 function fused_messages!(session::Session)
     messages = get_messages!(session)
-    return Dict(:msg_type=>FusedMessage, :payload=>messages)
+    caches = map(messages) do msg
+        data = copy(msg.session_cache)
+        empty!(msg.session_cache)
+        return data
+    end
+    return Dict(
+        :msg_type => FusedMessage,
+        :payload => [SessionCaches(caches), messages],
+    )
 end
 
 function init_session(session::Session)
@@ -161,8 +169,6 @@ function send_large(session::Session, message)
         push!(session.message_queue, serialized)
     end
 end
-
-
 
 function Sockets.send(session::Session, message::Dict{Symbol, Any})
     serialized = SerializedMessage(session, message)

--- a/src/types.jl
+++ b/src/types.jl
@@ -76,6 +76,7 @@ mutable struct SubConnection <: FrontendConnection
 end
 
 struct SerializedMessage
+    session_cache::Vector{UInt8}
     bytes::Vector{UInt8}
 end
 

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -7,13 +7,14 @@
     dom = App(DOM.div(test=obs1, onload=js"$(TestLib).lol()"))
     sdom = Bonito.session_dom(session, dom; init=false) # Init false to not inline messages
     msg = Bonito.fused_messages!(session)
-    data = Bonito.serialize_cached(session, msg)
-    decoded = Bonito.deserialize(msg[:payload][1]) |> Bonito.decode_extension_and_addbits
+    cache, data = Bonito.serialize_cached(session, msg)
+    decoded = Bonito.decode_extension_and_addbits(Bonito.deserialize(msg[:payload][2][1]))
     mapped = obs1.listeners[1][2].result # we map(render, obs1) when rendering attributes, so only that will be in the session
     @test haskey(session.session_objects, mapped.id)
     # Obs registered correctly
     @test mapped.listeners[1][2] isa Bonito.JSUpdateObservable
-    session_cache = decoded[1]
+    session_caches = Bonito.decode_extension_and_addbits.(Bonito.unpack.(msg[:payload][1].bytes))
+    session_cache = session_caches[1]
     @test session_cache isa Bonito.SessionCache
     @test haskey(session_cache.objects, mapped.id)
     @test haskey(session.session_objects, mapped.id)
@@ -21,7 +22,7 @@
     # Will deregisters correctly on session close
     @test length(session.deregister_callbacks) == 1
     @test session.deregister_callbacks[1].observable === obs1
-    @test occursin("Bonito.update_node_attribute", string(decoded[2]["payload"]))
+    @test occursin("Bonito.update_node_attribute", string(decoded["payload"]))
     close(session)
     @test isempty(obs1.listeners)
     @test isempty(mapped.listeners)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,9 @@ end
 @testset "Bonito" begin
     global edisplay = Bonito.use_electron_display(; devtools=true)
     @testset "Default Connection" begin
+        @testset "basics" begin
+            include("basics.jl")
+        end
         @testset "components" begin
             include("components.jl")
         end
@@ -87,9 +90,6 @@ end
         # @testset "various" begin; include("various.jl"); end
         @testset "markdown" begin
             include("markdown.jl")
-        end
-        @testset "basics" begin
-            include("basics.jl")
         end
     end
     close(edisplay)


### PR DESCRIPTION
This helps to send all observables and other cached objects in one go for `fused_messages!` which decouples any ordering problems from rendering the DOM.


