### PR TITLE
make it less necessary to set proxy_url

### DIFF
--- a/js_dependencies/Websocket.bundled.js
+++ b/js_dependencies/Websocket.bundled.js
@@ -107,7 +107,7 @@ class Websocket {
 }
 function websocket_url(session_id, proxy_url) {
     let http_url = window.location.protocol + "//" + window.location.host;
-    if (proxy_url) {
+    if (proxy_url !== "") {
         http_url = proxy_url;
     }
     let ws_url = http_url.replace("http", "ws");

--- a/js_dependencies/Websocket.js
+++ b/js_dependencies/Websocket.js
@@ -147,7 +147,7 @@ class Websocket {
 function websocket_url(session_id, proxy_url) {
     // something like http://127.0.0.1:8081/
     let http_url = window.location.protocol + "//" + window.location.host;
-    if (proxy_url) {
+    if (proxy_url !== "") {
         http_url = proxy_url;
     }
     let ws_url = http_url.replace("http", "ws");

--- a/src/HTTPServer/implementation.jl
+++ b/src/HTTPServer/implementation.jl
@@ -212,6 +212,19 @@ function online_url(server::Server, url)
     end
 end
 
+function relative_url(server::Server, url)
+    base_url = server.proxy_url
+    if isempty(base_url)
+        url = startswith(url, "/") ? url[2:end] : url
+        return "./" * url
+    else
+        if endswith(base_url, "/") && startswith(url, "/")
+            url = url[2:end]
+        end
+        return base_url * url
+    end
+end
+
 function stream_handler(application::Server, stream::Stream)
     if HTTP.WebSockets.isupgrade(stream.message)
         try

--- a/src/asset-serving/http.jl
+++ b/src/asset-serving/http.jl
@@ -72,7 +72,7 @@ function refs_and_url(server, asset::AbstractAsset)
     if asset isa Asset && asset.es6module
         key = key * "?" * asset.content_hash[]
     end
-    return refs, HTTPServer.online_url(server.server, key)
+    return refs, HTTPServer.relative_url(server.server, key)
 end
 
 function url(server::HTTPAssetServer, asset::AbstractAsset)

--- a/src/connection/dual-websocket.jl
+++ b/src/connection/dual-websocket.jl
@@ -71,7 +71,7 @@ function setup_connection(session::Session, connection::DualWebsocket)
     add_cleanup_task!(server)
     HTTPServer.websocket_route!(server, "/$(session.id)?low_latency" => connection)
     HTTPServer.websocket_route!(server, "/$(session.id)?large_data" => connection)
-    external_url = online_url(server, "")
+    external_url = server.proxy_url
     js_ll = setup_websocket_connection_js(external_url, session; query="?low_latency")
     js_ld = setup_websocket_connection_js(external_url, session; query="?large_data", main_connection=false)
     return js"{

--- a/src/connection/websocket.jl
+++ b/src/connection/websocket.jl
@@ -190,12 +190,7 @@ function setup_connection(session::Session, connection::WebSocketConnection)
     server = connection.server
     add_cleanup_task!(server)
     HTTPServer.websocket_route!(server, "/$(session.id)" => connection)
-    if isempty(server.proxy_url)
-        external_url = ""
-    else
-        external_url = online_url(server, "")
-    end
-    return setup_websocket_connection_js(external_url, session)
+    return setup_websocket_connection_js(server.proxy_url, session)
 end
 
 function setup_connection(session::Session{WebSocketConnection})

--- a/src/connection/websocket.jl
+++ b/src/connection/websocket.jl
@@ -190,7 +190,11 @@ function setup_connection(session::Session, connection::WebSocketConnection)
     server = connection.server
     add_cleanup_task!(server)
     HTTPServer.websocket_route!(server, "/$(session.id)" => connection)
-    external_url = online_url(server, "")
+    if isempty(server.proxy_url)
+        external_url = ""
+    else
+        external_url = online_url(server, "")
+    end
     return setup_websocket_connection_js(external_url, session)
 end
 

--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -134,13 +134,7 @@ function configure_server!(;
     end
 
     if isnothing(proxy_url)
-        if listen_url == "0.0.0.0"
-            proxy_url = string(Sockets.getipaddr(), ":$forwarded_port")
-        elseif listen_url in ("127.0.0.1", "localhost")
-            proxy_url = "http://localhost:$forwarded_port"
-        else
-            error("Trying to listen to $(listen_url), while only \"127.0.0.1\", \"0.0.0.0\" and \"localhost\" are supported")
-        end
+        proxy_url = ""
     end
     # set the config!
     SERVER_CONFIGURATION.listen_url[] = listen_url

--- a/src/server-defaults.jl
+++ b/src/server-defaults.jl
@@ -62,7 +62,7 @@ function find_proxy_in_environment()
         return port-> ENV["JH_APP_URL"] * "proxy/$(port)"
     elseif haskey(ENV, "JULIA_WEBIO_BASEURL")
         # Possibly not working anymore, but used to be used in e.g. nextjournal for the proxy url
-        return ENV["JULIA_WEBIO_BASEURL"]
+        return port-> ENV["JULIA_WEBIO_BASEURL"]
     elseif haskey(ENV, "BINDER_SERVICE_HOST")
         # binder
         return port -> ENV["BINDER_SERVICE_HOST"] * "proxy/$port"

--- a/test/connection-serving.jl
+++ b/test/connection-serving.jl
@@ -22,9 +22,15 @@ connections = [
 servers = [(:NoServer, () -> NoServer()), (:HTTPAssetServer, () -> HTTPAssetServer())]
 
 path = joinpath(@__DIR__, "test.html")
+
+# We need to use a proxy url to not have relative URLS for HTTPAssetServer, when serving from a file.
+s = Bonito.get_server()
+Bonito.configure_server!(proxy_url="http://localhost:$(s.port)")
+
 @testset "connection $(c) server: $(s)" for ((c, connection), (s, server)) in Iterators.product(connections, servers)
     app = App(export_test_app)
-    export_static(path, app; connection=connection(), asset_server=server())
+    s = server()
+    sess = export_static(path, app; connection=connection(), asset_server=s)
     # We need to drop a bit lower and cant use `testapp` here, since that uses fixed connection + asset server
     window = Bonito.EWindow(URI("file://" * path))
     sleep(0.5) # how did this work before without syncronization?
@@ -34,6 +40,8 @@ path = joinpath(@__DIR__, "test.html")
     close(app)
 end
 rm(path; force=true)
+Bonito.configure_server!(proxy_url=nothing)
+
 
 # Finalizers and other problems have been closing our connection unintentional,
 # So we do this little stress test:


### PR DESCRIPTION
This sets the proxy_url by default to `""`, which then makes the websocket connection use `window.href` as a base while the the http asset_server uses `HTTPServer.relative_url(server, address...)`, which appends the proxy_url only if set and otherwise leaves it at `./`. This means in most setups, one doesn't need to set `proxy_url` anymore.
One still needs to set it, if the route for reaching the bonito server is completely different, e.g. if it's proxied as for JuliaHub, or other more complex nginx setups etc.