### PR TITLE
serialized message refactor

### DIFF
--- a/src/HTTPServer/implementation.jl
+++ b/src/HTTPServer/implementation.jl
@@ -255,7 +255,7 @@ function stream_handler(application::Server, stream::Stream)
     catch e
         # we expect the IOError to happen, if either the page gets closed
         # or we close the server!
-        if !(e isa Base.IOError && (e.msg == "stream is closed or unusable" || e.code == -4081))
+        if !(e isa Base.IOError)
             rethrow(e)
         end
     end

--- a/src/app.jl
+++ b/src/app.jl
@@ -165,7 +165,8 @@ function HTTPServer.apply_handler(handler::DisplayHandler, context)
 end
 
 function wait_for_ready(app::App; timeout=100)
-    wait_for(()-> !isnothing(app.session[]); timeout=timeout)
+    success = wait_for(()-> !isnothing(app.session[]); timeout=timeout)
+    success !== :success && return nothing
     isclosed(app.session[]) && return nothing
     wait_for(timeout=timeout) do
         isready(app.session[]) || isclosed(app.session[])

--- a/src/asset-serving/http.jl
+++ b/src/asset-serving/http.jl
@@ -116,7 +116,7 @@ function (server::HTTPAssetServer)(context)
         _, asset = rf[path]
         if asset isa BinaryAsset
             header = ["Access-Control-Allow-Origin" => "*",
-                "Content-Type" => "application/octet-stream"]
+                "Content-Type" => asset.mime]
             return HTTP.Response(200, header; body=asset.data)
         else
             data = nothing

--- a/src/connection/dual-websocket.jl
+++ b/src/connection/dual-websocket.jl
@@ -64,7 +64,6 @@ function (connection::DualWebsocket)(context, websocket::WebSocket)
     end
 end
 
-
 function setup_connection(session::Session, connection::DualWebsocket)
     connection.session = session
     server = connection.server

--- a/src/connection/dual-websocket.jl
+++ b/src/connection/dual-websocket.jl
@@ -16,7 +16,7 @@ end
 
 Base.isopen(ws::DualWebsocket) = isopen(ws.low_latency)
 
-function Base.write(ws::DualWebsocket, binary)
+function Base.write(ws::DualWebsocket, binary::AbstractVector{UInt8})
     write(ws.low_latency, binary)
 end
 

--- a/src/connection/no-connection.jl
+++ b/src/connection/no-connection.jl
@@ -1,6 +1,6 @@
 struct NoConnection <: FrontendConnection end
 
-function Base.write(connection::NoConnection, data)
+function Base.write(connection::NoConnection, data::AbstractVector{UInt8})
     error("Can't communicate with Frontend with no Connection")
 end
 

--- a/src/connection/pluto.jl
+++ b/src/connection/pluto.jl
@@ -8,7 +8,7 @@ PlutoConnection() = PlutoConnection(WebSocketConnection())
 
 Base.isopen(pluto::PlutoConnection) = isopen(pluto.connection)
 
-function Base.write(ws::PlutoConnection, binary)
+function Base.write(ws::PlutoConnection, binary::AbstractVector{UInt8})
     write(ws.connection, binary)
 end
 

--- a/src/connection/sub-connection.jl
+++ b/src/connection/sub-connection.jl
@@ -4,7 +4,11 @@ function SubConnection(parent::Session)
     return SubConnection(parent.connection, false)
 end
 
-function Base.write(connection::SubConnection, binary::Union{SerializedMessage, AbstractVector{UInt8}})
+function Base.write(connection::SubConnection, msg::SerializedMessage)
+    write(connection.connection, msg)
+end
+
+function Base.write(connection::SubConnection, binary::AbstractVector{UInt8})
     write(connection.connection, binary)
 end
 

--- a/src/connection/sub-connection.jl
+++ b/src/connection/sub-connection.jl
@@ -4,7 +4,7 @@ function SubConnection(parent::Session)
     return SubConnection(parent.connection, false)
 end
 
-function Base.write(connection::SubConnection, binary)
+function Base.write(connection::SubConnection, binary::Union{SerializedMessage, AbstractVector{UInt8}})
     write(connection.connection, binary)
 end
 

--- a/src/connection/websocket-handler.jl
+++ b/src/connection/websocket-handler.jl
@@ -51,7 +51,7 @@ function Base.isopen(ws::WebSocketHandler)
     return true
 end
 
-function Base.write(ws::WebSocketHandler, binary)
+function Base.write(ws::WebSocketHandler, binary::AbstractVector{UInt8})
     if isnothing(ws.socket)
         error("socket closed or not opened yet")
     end

--- a/src/connection/websocket-handler.jl
+++ b/src/connection/websocket-handler.jl
@@ -13,6 +13,7 @@ WebSocketHandler() = WebSocketHandler(nothing, ReentrantLock())
 function ws_should_throw(e)
     WebSockets.isok(e) && return false
     e isa Union{Base.IOError,EOFError} && return false
+    e isa ArgumentError && e.msg == "send() requires `!(ws.writeclosed)`" && return false
     return true
 end
 

--- a/src/connection/websocket-handler.jl
+++ b/src/connection/websocket-handler.jl
@@ -40,23 +40,25 @@ function safe_write(websocket, binary)
 end
 
 function Base.isopen(ws::WebSocketHandler)
-    isnothing(ws.socket) && return false
-    # isclosed(ws.socket) returns readclosed && writeclosed
-    # but we consider it closed if either is closed?
-    if ws.socket.readclosed || ws.socket.writeclosed
-        return false
+    lock(ws.lock) do
+        isnothing(ws.socket) && return false
+        # isclosed(ws.socket) returns readclosed && writeclosed
+        # but we consider it closed if either is closed?
+        if ws.socket.readclosed || ws.socket.writeclosed
+            return false
+        end
+        # So, it turns out, ws connection where the tab gets closed
+        # stay open indefinitely, but aren't writable anymore
+        # TODO, figure out how to check for that
+        return true
     end
-    # So, it turns out, ws connection where the tab gets closed
-    # stay open indefinitely, but aren't writable anymore
-    # TODO, figure out how to check for that
-    return true
 end
 
 function Base.write(ws::WebSocketHandler, binary::AbstractVector{UInt8})
-    if isnothing(ws.socket)
-        error("socket closed or not opened yet")
-    end
     lock(ws.lock) do
+        if isnothing(ws.socket)
+            error("socket closed or not opened yet")
+        end
         written = safe_write(ws.socket, binary)
         if written != true
             @debug "couldnt write, closing ws"
@@ -66,13 +68,15 @@ function Base.write(ws::WebSocketHandler, binary::AbstractVector{UInt8})
 end
 
 function Base.close(ws::WebSocketHandler)
-    isnothing(ws.socket) && return
-    try
-        socket = ws.socket
-        ws.socket = nothing
-        isclosed(socket) || close(socket)
-    catch e
-        ws_should_throw(e) && @warn "error while closing websocket" exception=(e, Base.catch_backtrace())
+    lock(ws.lock) do
+        isnothing(ws.socket) && return
+        try
+            socket = ws.socket
+            ws.socket = nothing
+            isclosed(socket) || close(socket)
+        catch e
+            ws_should_throw(e) && @warn "error while closing websocket" exception=e
+        end
     end
 end
 

--- a/src/connection/websocket.jl
+++ b/src/connection/websocket.jl
@@ -15,7 +15,7 @@ end
 
 Base.isopen(ws::WebSocketConnection) = isopen(ws.handler)
 
-function Base.write(ws::WebSocketConnection, binary)
+function Base.write(ws::WebSocketConnection, binary::AbstractVector{UInt8})
     write(ws.handler, binary)
 end
 

--- a/src/rendering/observables.jl
+++ b/src/rendering/observables.jl
@@ -29,11 +29,9 @@ function (x::JSUpdateObservable)(@nospecialize(value))
             send(x.session, msg; large=is_large)
         end
     catch e
-        @error "Error in JSUpdateObservable:" exception=(e, catch_backtrace())
+        @debug "Error while sending update for JSUpdateObservable" exception=e
     end
 end
-
-
 
 
 """

--- a/src/serialization/caching.jl
+++ b/src/serialization/caching.jl
@@ -9,14 +9,8 @@ end
 
 object_identity(retain::Retain) = object_identity(retain.value)
 object_identity(obs::Observable) = obs.id
+object_identity(obj::Any) = string(hash(obj))
 
-function serialize_cached(context::SerializationContext, retain::Retain)
-    return add_cached!(context.session, context.message_cache, retain) do
-        obs = retain.value
-        register_observable!(context.session, obs)
-        return Retain(SerializedObservable(obs.id, serialize_cached(context, obs[])))
-    end
-end
 
 function register_observable!(session::Session, obs::Observable)
     # Always register with root session!
@@ -31,6 +25,15 @@ function register_observable!(session::Session, obs::Observable)
         on(updater, obs)
     end
     return
+end
+
+
+function serialize_cached(context::SerializationContext, retain::Retain)
+    return add_cached!(context.session, context.message_cache, retain) do
+        obs = retain.value
+        register_observable!(context.session, obs)
+        return Retain(SerializedObservable(obs.id, serialize_cached(context, obs[])))
+    end
 end
 
 function serialize_cached(context::SerializationContext, obs::Observable)

--- a/src/serialization/msgpack.jl
+++ b/src/serialization/msgpack.jl
@@ -118,9 +118,14 @@ function MsgPack.to_msgpack(::MsgPack.ExtensionType, x::SessionCache)
     return MsgPack.Extension(SESSION_CACHE_TAG, pack([x.session_id, x.objects, x.session_type]))
 end
 
+MsgPack.msgpack_type(::Type{BinaryMessage}) = MsgPack.ExtensionType()
+function MsgPack.to_msgpack(::MsgPack.ExtensionType, x::BinaryMessage)
+    return MsgPack.Extension(SERIALIZED_MESSAGE_TAG, x.bytes)
+end
+
 MsgPack.msgpack_type(::Type{SerializedMessage}) = MsgPack.ExtensionType()
 function MsgPack.to_msgpack(::MsgPack.ExtensionType, x::SerializedMessage)
-    return MsgPack.Extension(SERIALIZED_MESSAGE_TAG, x.bytes)
+    return MsgPack.Extension(SERIALIZED_MESSAGE_TAG, pack([x.cache, x.data]))
 end
 
 

--- a/src/serialization/types.jl
+++ b/src/serialization/types.jl
@@ -11,24 +11,18 @@ struct Retain
     value::Union{Observable, SerializedObservable} # For now, restricted to observable!
 end
 
-struct SerializedJSCode
-    interpolated_objects::Dict{String, Any}
-    source::String
-    julia_file::String
-end
-
-struct SessionCache
-    session_id::String
-    objects::Dict{String, Any}
-    session_type::String
-end
-
-function SessionCache(session::Session, objects::Dict{String,Any})
+function SessionCache(session::Session, objects::AbstractDict{String,Any})
     return SessionCache(
         session.id,
         objects,
         root_session(session) === session ? "root" : "sub",
     )
+end
+
+struct SerializedJSCode
+    interpolated_objects::Dict{String, Any}
+    source::String
+    julia_file::String
 end
 
 # We want typed arrays to arrive as JS typed arrays

--- a/src/types.jl
+++ b/src/types.jl
@@ -75,7 +75,19 @@ mutable struct SubConnection <: FrontendConnection
     isopen::Bool
 end
 
+struct SessionCache
+    session_id::String
+    objects::Dict{String, Any}
+    session_type::String
+end
+
 struct SerializedMessage
+    cache::SessionCache
+    data::Any
+    compression::Bool
+end
+
+struct BinaryMessage
     bytes::Vector{UInt8}
 end
 
@@ -253,6 +265,7 @@ mutable struct Session{Connection <: FrontendConnection}
             inbox,
             Threads.threadid()
         )
+
         task = Task() do
             for message in inbox
                 try

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -7,13 +7,13 @@
     dom = App(DOM.div(test=obs1, onload=js"$(TestLib).lol()"))
     sdom = Bonito.session_dom(session, dom; init=false) # Init false to not inline messages
     msg = Bonito.fused_messages!(session)
-    data = Bonito.serialize_cached(session, msg)
-    decoded = Bonito.deserialize(msg[:payload][1]) |> Bonito.decode_extension_and_addbits
+    data = Bonito.SerializedMessage(session, msg)
+    decoded = msg[:payload][1]
     mapped = obs1.listeners[1][2].result # we map(render, obs1) when rendering attributes, so only that will be in the session
     @test haskey(session.session_objects, mapped.id)
     # Obs registered correctly
     @test mapped.listeners[1][2] isa Bonito.JSUpdateObservable
-    session_cache = decoded[1]
+    session_cache = decoded.cache
     @test session_cache isa Bonito.SessionCache
     @test haskey(session_cache.objects, mapped.id)
     @test haskey(session.session_objects, mapped.id)
@@ -21,7 +21,7 @@
     # Will deregisters correctly on session close
     @test length(session.deregister_callbacks) == 1
     @test session.deregister_callbacks[1].observable === obs1
-    @test occursin("Bonito.update_node_attribute", string(decoded[2]["payload"]))
+    @test occursin("Bonito.update_node_attribute", string(decoded.data["payload"]))
     close(session)
     @test isempty(obs1.listeners)
     @test isempty(mapped.listeners)

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -32,7 +32,7 @@ struct DebugConnection <: Bonito.FrontendConnection
 end
 
 DebugConnection() = DebugConnection(IOBuffer())
-Base.write(connection::DebugConnection, bytes) = write(connection.io, bytes)
+Base.write(connection::DebugConnection, bytes::AbstractVector{UInt8}) = write(connection.io, bytes)
 Base.isopen(connection::DebugConnection) = isopen(connection.io)
 Base.close(connection::DebugConnection) = close(connection.io)
 setup_connection(session::Session{DebugConnection}) = nothing


### PR DESCRIPTION
Factor out the SerilizedMessage -> BinaryMessage refactor from: Moves back the work of going from dict -> binary for send(connection, msg), so that it can be done in the websocket handler
So this PR only cleans up sending large_write, and only serializing to the Dict form for any message (especially queued messages), instead of going full binary. Binary serialization is left to the connection.
The connection can now optionally accept `SerializedMessage` by overloading ` write(::Connection, ::SerializedMessage)`.