### PR TITLE
Use async for processing messages

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -312,7 +312,7 @@ mutable struct Session{Connection <: FrontendConnection}
 
         task = Task() do
             for message in inbox
-                try
+                @async try
                     process_message(session, message)
                 catch e
                     @warn "error while processing received msg" exception = (


### PR DESCRIPTION
So, it's super easy to block evaljs_value indefinitely without processing messages in an `@async`:
```julia
obs = Observable(1)
js"""
$(obs).notify(22)
"""
on(obs) do val 
    evaljs_value(session, js"...")
end
```
The reasons is, that evaljs_value blocks until a message returns from JS, but that message never arrives, since the event loop is blocked by working on the `obs` notify which triggert the `evaljs_value`.

This happens quite covertly e.g. if a user reacts to a HTML widgets which in turn inserts a new WGLMakie plot.
I guess we could force people to use async in their callback widgets, but I think this is too much of a footgun and hard to debug for unknowing users to run into.